### PR TITLE
readme typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# KMSAN (KernelMemorySanitier)
+# KMSAN (KernelMemorySanitizer)
 
 `KMSAN` is a detector of uninitialized memory use for the Linux kernel. It is
 currently in development.


### PR DESCRIPTION
Came across this typo in `README.md`:

`KMSAN (KernelMemorySanitier)` => Changed to: `KMSAN (KernelMemorySanitizer)`
 