### PR TITLE
kmsan: fix kfree() of unallocated memory in kmsan_vmap()

### DIFF
--- a/mm/kmsan/kmsan_hooks.c
+++ b/mm/kmsan/kmsan_hooks.c
@@ -151,7 +151,7 @@ void kmsan_vmap(struct vm_struct *area,
 		pgprot_t prot, void *caller)
 {
 	struct vm_struct *shadow, *origin;
-	struct page **s_pages, **o_pages;
+	struct page **s_pages = NULL, **o_pages = NULL;
 	unsigned long irq_flags, size;
 	int i;
 


### PR DESCRIPTION
kfree(o_pages) can try to free an unallocated memory in case "if (!s_pages) goto err_free;" and
o_pages contains garbage from a stack. fix this by initializing o_pages and s_pages, just in case.

Reported-by: https://syzkaller.appspot.com/bug?id=ae239a8b52cf47d202f7ca93d3e861499f9dffcd
Reported-by: https://syzkaller.appspot.com/text?tag=CrashReport&x=104ebce1400000