### PR TITLE
igmp: reset buf before any memory access

### DIFF
--- a/net/ipv4/igmp.c
+++ b/net/ipv4/igmp.c
@@ -1131,6 +1131,8 @@ static void ip_mc_filter_add(struct in_device *in_dev, __be32 addr)
 	char buf[MAX_ADDR_LEN];
 	struct net_device *dev = in_dev->dev;
 
+	memset(&buf, 0, MAX_ADDR_LEN);
+
 	/* Checking for IFF_MULTICAST here is WRONG-WRONG-WRONG.
 	   We will get multicast token leakage, when IFF_MULTICAST
 	   is changed. This check should be done in ndo_set_rx_mode
@@ -1150,6 +1152,8 @@ static void ip_mc_filter_del(struct in_device *in_dev, __be32 addr)
 {
 	char buf[MAX_ADDR_LEN];
 	struct net_device *dev = in_dev->dev;
+
+	memset(&buf, 0, MAX_ADDR_LEN);
 
 	if (arp_mc_map(addr, buf, dev, 0) == 0)
 		dev_mc_del(dev, buf);

--- a/net/ipv6/mcast.c
+++ b/net/ipv6/mcast.c
@@ -662,6 +662,7 @@ static void igmp6_group_added(struct ifmcaddr6 *mc)
 	    IPV6_ADDR_SCOPE_LINKLOCAL)
 		return;
 
+	memset(&buf, 0, MAX_ADDR_LEN);
 	spin_lock_bh(&mc->mca_lock);
 	if (!(mc->mca_flags&MAF_LOADED)) {
 		mc->mca_flags |= MAF_LOADED;
@@ -698,6 +699,7 @@ static void igmp6_group_dropped(struct ifmcaddr6 *mc)
 	    IPV6_ADDR_SCOPE_LINKLOCAL)
 		return;
 
+	memset(&buf, 0, MAX_ADDR_LEN);
 	spin_lock_bh(&mc->mca_lock);
 	if (mc->mca_flags&MAF_LOADED) {
 		mc->mca_flags &= ~MAF_LOADED;


### PR DESCRIPTION
My own fork of KMSAN cannot test with syzbot. So I try to push it to the google/kmsan

> KMSAN bugs can only be tested on https://github.com/google/kmsan.git tree
> because KMSAN tool is not upstreamed yet.



[1] <https://syzkaller.appspot.com/bug?id=a84ac404cf07db753e289b918981964b540359bd>